### PR TITLE
get_version() should add auth headers

### DIFF
--- a/jenkins/__init__.py
+++ b/jenkins/__init__.py
@@ -482,6 +482,8 @@ class Jenkins(object):
         try:
             request = Request(self._build_url(''))
             request.add_header('X-Jenkins', '0.0')
+            if self.auth:
+                request.add_header('Authorization', self.auth)
             response = urlopen(request, timeout=self.timeout)
             if response is None:
                 raise EmptyResponseException(


### PR DESCRIPTION
Jenkins can be configured to always require authorized access, so we need to add the auth headers even to get_version requestions.