### PR TITLE
Add support for passing SSL context to urllib

### DIFF
--- a/jenkins/__init__.py
+++ b/jenkins/__init__.py
@@ -253,7 +253,7 @@ def auth_headers(username, password):
 class Jenkins(object):
 
     def __init__(self, url, username=None, password=None,
-                 timeout=socket._GLOBAL_DEFAULT_TIMEOUT):
+                 timeout=socket._GLOBAL_DEFAULT_TIMEOUT, ssl_context=None):
         '''Create handle to Jenkins instance.
 
         All methods will raise :class:`JenkinsException` on failure.
@@ -262,6 +262,7 @@ class Jenkins(object):
         :param password: Server password, ``str``
         :param url: URL of Jenkins server, ``str``
         :param timeout: Server connection timeout in secs (default: not set), ``int``
+        :param ssl_context: SSL context used by urlopen ``ssl.SSLContext``
         '''
         if url[-1] == '/':
             self.server = url
@@ -273,6 +274,7 @@ class Jenkins(object):
             self.auth = None
         self.crumb = None
         self.timeout = timeout
+        self.ssl_context = ssl_context
 
     def _get_encoded_params(self, params):
         for k, v in params.items():
@@ -385,7 +387,7 @@ class Jenkins(object):
                 req.add_header('Authorization', self.auth)
             if add_crumb:
                 self.maybe_add_crumb(req)
-            response = urlopen(req, timeout=self.timeout).read()
+            response = urlopen(req, timeout=self.timeout, context=self.ssl_context).read()
             if response is None:
                 raise EmptyResponseException(
                     "Error communicating with server[%s]: "
@@ -529,7 +531,7 @@ class Jenkins(object):
         try:
             request = Request(self._build_url(''))
             request.add_header('X-Jenkins', '0.0')
-            response = urlopen(request, timeout=self.timeout)
+            response = urlopen(request, timeout=self.timeout, context=self.ssl_context)
             if response is None:
                 raise EmptyResponseException(
                     "Error communicating with server[%s]: "


### PR DESCRIPTION
This can be useful when testing towards a Jenkins instance with a selfsigned SSL certificate.

Specifically I would like to add a command line option `--no-check-certificate` to [jenkins-job-builder](https://github.com/openstack-infra/jenkins-job-builder) just like tools like curl / wget has.

This would then be used like this to turn off the verification of the certificate:

```python
ctx = ssl.create_default_context()
ctx.check_hostname = False
ctx.verify_mode = ssl.CERT_NONE

server = jenkins.Jenkins('https://jenkins.local', ssl_context=ctx)
```