### PR TITLE
A bug in extracting job name from get_node_info

### DIFF
--- a/jenkins/__init__.py
+++ b/jenkins/__init__.py
@@ -1080,7 +1080,7 @@ class Jenkins(object):
                     executor_number = executor['number']
                     build_number = executable['number']
                     url = executable['url']
-                    m = re.match(r'/job/([^/]+)/.*', urlparse(url).path)
+                    m = re.match(r'.*/job/([^/]+)/.*', urlparse(url).path)
                     job_name = m.group(1)
                     builds.append({'name': job_name,
                                    'number': build_number,


### PR DESCRIPTION
Jenkins url can be like this:
http://yourIP:port/prefix/
then the url of a job from get_node_info() will be:
http://yourIP:port/prefix/job/yourJob/buildNumber
In this situation, urlparse(url).path will be:
/prefix/job/yourJob/buildNumber
then you execute re.match(r'.*/job/([^/]+)/.*', urlparse(url).path), and you wiil get this error:
Traceback (most recent call last):
  File "./zz.py", line 23, in <module>
    jobname=m.group(1)
AttributeError: 'NoneType' object has no attribute 'group'