### PR TITLE
Exclude executors which are placeholders for tasks

### DIFF
--- a/jenkins/__init__.py
+++ b/jenkins/__init__.py
@@ -1145,7 +1145,8 @@ class Jenkins(object):
                     raise
             for executor in info['executors']:
                 executable = executor['currentExecutable']
-                if executable:
+                if (executable and
+                        'PlaceholderTask' not in executable['_class']):
                     executor_number = executor['number']
                     build_number = executable['number']
                     url = executable['url']


### PR DESCRIPTION
On a busy Jenkins setups, quite often `executable['_class']` is
`org.jenkinsci.plugins.workflow.support.steps.ExecutorStepExecution$PlaceholderTask$PlaceholderExecutable` - it won't have all the job attributes set yet as it's a placeholde for a job; don't try to process them