### PR TITLE
Should use fullname instead of name

### DIFF
--- a/jenkins/__init__.py
+++ b/jenkins/__init__.py
@@ -384,7 +384,7 @@ class Jenkins(object):
         jobs = self.get_all_jobs(folder_depth)
         for job in jobs:
             if re.search(pattern, job['name']):
-                result.append(self.get_job_info(job['name'], depth=depth))
+                result.append(self.get_job_info(job['fullname'], depth=depth))
 
         return result
 


### PR DESCRIPTION
`get_job_info_regex` should use `fullname` instead of `name` otherwise it will fail if the matched job is inside a folder.

For example, given the above structure:
```
job1
frontend/
  front-build
  front-deploy
job2
```

If we execute this code:
```python
jobs = server.get_job_info_regex(pattern='front', folder_depth=None)
```

We will get the following error:
```
jenkins.NotFoundException: Requested item could not be found
```

Because we're not sending the folder name to `_get_job_folder`.