### PR TITLE
replace spaces in urls

### DIFF
--- a/jenkins/__init__.py
+++ b/jenkins/__init__.py
@@ -293,6 +293,8 @@ class Jenkins(object):
         else:
             url_path = format_spec
 
+        url_path = url_path.replace(' ', '%20')
+        
         return urljoin(self.server, url_path)
 
     def maybe_add_crumb(self, req):


### PR DESCRIPTION
Replaces spaces in Jenkins URLs with `%20`. I ran into this issue when running `jenkins-job-builder` against jobs with spaces in their names and it always failed. If this gets merged, updating the dependency in `jenkins-job-builder` will have to happen as well as perhaps a few others relying on it.