### PR TITLE
Fix: pass empty dict for proxies

### DIFF
--- a/jenkins/__init__.py
+++ b/jenkins/__init__.py
@@ -521,7 +521,7 @@ class Jenkins(object):
         # requests.Session.send() does not honor env settings by design
         # see https://github.com/requests/requests/issues/2807
         _settings = self._session.merge_environment_settings(
-            r.url, None, None, self._session.verify, None)
+            r.url, {}, None, self._session.verify, None)
         _settings['timeout'] = self.timeout
         return self._session.send(r, **_settings)
 


### PR DESCRIPTION
This is a fix for the following error:
```
Traceback (most recent call last):
  File "/var/lib/jenkins/shiningpanda/jobs/b14abac8/virtualenvs/d41d8cd9/bin/jenkins-jobs", line 11, in <module>
    sys.exit(main())
  File "/var/lib/jenkins/shiningpanda/jobs/b14abac8/virtualenvs/d41d8cd9/lib/python3.5/site-packages/jenkins_jobs/cli/entry.py", line 146, in main
    jjb.execute()
  File "/var/lib/jenkins/shiningpanda/jobs/b14abac8/virtualenvs/d41d8cd9/lib/python3.5/site-packages/jenkins_jobs/cli/entry.py", line 140, in execute
    ext.obj.execute(self.options, self.jjb_config)
  File "/var/lib/jenkins/shiningpanda/jobs/b14abac8/virtualenvs/d41d8cd9/lib/python3.5/site-packages/jenkins_jobs/cli/subcommand/update.py", line 148, in execute
    n = builder.delete_old_managed(keep=keep_jobs)
  File "/var/lib/jenkins/shiningpanda/jobs/b14abac8/virtualenvs/d41d8cd9/lib/python3.5/site-packages/jenkins_jobs/builder.py", line 187, in delete_old_managed
    jobs = self.get_jobs()
  File "/var/lib/jenkins/shiningpanda/jobs/b14abac8/virtualenvs/d41d8cd9/lib/python3.5/site-packages/jenkins_jobs/builder.py", line 168, in get_jobs
    return self.jobs
  File "/var/lib/jenkins/shiningpanda/jobs/b14abac8/virtualenvs/d41d8cd9/lib/python3.5/site-packages/jenkins_jobs/builder.py", line 96, in jobs
    self._jobs = self.jenkins.get_all_jobs()
  File "/var/lib/jenkins/shiningpanda/jobs/b14abac8/virtualenvs/d41d8cd9/lib/python3.5/site-packages/jenkins/__init__.py", line 951, in get_all_jobs
    jobs = [(0, "", self.get_info(query=JOBS_QUERY)['jobs'])]
  File "/var/lib/jenkins/shiningpanda/jobs/b14abac8/virtualenvs/d41d8cd9/lib/python3.5/site-packages/jenkins/__init__.py", line 694, in get_info
    requests.Request('GET', self._build_url(INFO))
  File "/var/lib/jenkins/shiningpanda/jobs/b14abac8/virtualenvs/d41d8cd9/lib/python3.5/site-packages/jenkins/__init__.py", line 533, in jenkins_open
    return self.jenkins_request(req, add_crumb, resolve_auth).text
  File "/var/lib/jenkins/shiningpanda/jobs/b14abac8/virtualenvs/d41d8cd9/lib/python3.5/site-packages/jenkins/__init__.py", line 549, in jenkins_request
    self.maybe_add_crumb(req)
  File "/var/lib/jenkins/shiningpanda/jobs/b14abac8/virtualenvs/d41d8cd9/lib/python3.5/site-packages/jenkins/__init__.py", line 347, in maybe_add_crumb
    'GET', self._build_url(CRUMB_URL)), add_crumb=False)
  File "/var/lib/jenkins/shiningpanda/jobs/b14abac8/virtualenvs/d41d8cd9/lib/python3.5/site-packages/jenkins/__init__.py", line 533, in jenkins_open
    return self.jenkins_request(req, add_crumb, resolve_auth).text
  File "/var/lib/jenkins/shiningpanda/jobs/b14abac8/virtualenvs/d41d8cd9/lib/python3.5/site-packages/jenkins/__init__.py", line 552, in jenkins_request
    self._request(req))
  File "/var/lib/jenkins/shiningpanda/jobs/b14abac8/virtualenvs/d41d8cd9/lib/python3.5/site-packages/jenkins/__init__.py", line 524, in _request
    r.url, None, None, self._session.verify, None)
  File "/var/lib/jenkins/shiningpanda/jobs/b14abac8/virtualenvs/d41d8cd9/lib/python3.5/site-packages/jenkins/__init__.py", line 278, in merge_environment_settings
    **kwargs)
  File "/var/lib/jenkins/shiningpanda/jobs/b14abac8/virtualenvs/d41d8cd9/lib/python3.5/site-packages/requests/sessions.py", line 674, in merge_environment_settings
    proxies.setdefault(k, v)
AttributeError: 'NoneType' object has no attribute 'setdefault'
Build step 'Virtualenv Builder' marked build as failure
```

The Issue:
`requests` will accept `None` as a value for `proxies` in a `merge_environment_settings` call, but unsafely treats is as a dict a few lines into the call on [this line](https://github.com/requests/requests/blob/master/requests/sessions.py#L679) without coercing a `None` into an empty dict first.

The Fix:
I am also opening up a PR to `requests` to fix this behavior on their end, but passing an empty dict in is a "safer" approach from the `python-jenkins` side, if we want to hard-code an empty proxy value.