### PR TITLE
Fix get_version() to work with security enabled

### DIFF
--- a/jenkins/__init__.py
+++ b/jenkins/__init__.py
@@ -802,6 +802,8 @@ class Jenkins(object):
         """
         try:
             request = requests.Request('GET', self._build_url(''))
+            if self.auth:
+                request.add_header('Authorization', self.auth)
             request.headers['X-Jenkins'] = '0.0'
             response = self._response_handler(self._request(request))
 


### PR DESCRIPTION
See: https://stackoverflow.com/questions/40253108/get-jenkins-badhttpexception-when-try-to-get-version-info-from-jenkins-run-on-do/44346465#44346465